### PR TITLE
REST api endpoints corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Restful API endpoints for the resource “opengdpr_requests”:
 | HTTP Method | Path | Description | Supported? |
 | --- | --- | --- | --- |
 | POST | opengdpr_requests/ | Create a new OpenGDPR request | Yes |
-| GET | opengdpr_requests/ | Retrieve status of all OpenGDPR request | Yes |
 | GET | opengdpr_requests/{RequestId} | Retrieve status of a single OpenGDPR request | Yes |
 | PUT | opengdpr_requests/{RequestId} | - | No, requests cannot be updated after being created |
 | DELETE | opengdpr_requests/{RequestId} | Cancel an OpenGDPR request | Yes, cancellation is valid in status “pending” only |

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ Restful API endpoints for the resource “opengdpr_requests”:
 
 | HTTP Method | Path | Description | Supported? |
 | --- | --- | --- | --- |
-| POST | opengdpr_requests/<RequestId> | Create a new OpenGDPR request | Yes |
-| GET | opengdpr_requests/<RequestId> | Retrieve status of a single OpenGDPR request | Yes |
-| PUT | opengdpr_requests/<RequestId> | - | No, requests cannot be updated after being created |
-| DELETE | opengdpr_requests/<RequestId> | Cancel an OpenGDPR request | Yes, cancellation is valid in status “pending” only |
+| POST | opengdpr_requests/ | Create a new OpenGDPR request | Yes |
+| GET | opengdpr_requests/ | Retrieve status of all OpenGDPR request | Yes |
+| GET | opengdpr_requests/{RequestId} | Retrieve status of a single OpenGDPR request | Yes |
+| PUT | opengdpr_requests/{RequestId} | - | No, requests cannot be updated after being created |
+| DELETE | opengdpr_requests/{RequestId} | Cancel an OpenGDPR request | Yes, cancellation is valid in status “pending” only |
 
 Non-Restful endpoints:
 


### PR DESCRIPTION
Using angle brackets for <RequestId> was making it invisible in the README section. I've changed it to curly braces {RequestId}.
Also, a GET request to view **all of the open gdpr request** should be supported. Currently its just view by id.