### PR TITLE
Removed encoded request from DELETE response

### DIFF
--- a/OpenGDPR_specification.md
+++ b/OpenGDPR_specification.md
@@ -62,18 +62,18 @@ Enacting compliance related activities to honor an OpenGDPR request.
 ### 3.1. Roles and Responsibilities
 
 #### Data Subject
- 
+
   A European Union resident whose personal data is being processed.
 
 #### Data Controller
-  
+
   An entity which makes the decision about what personal data  will be processed and the types of processing that will be done with respect to that personal data. The Data Controller receives Data Subject requests from the Data Subjects and validates them. The Data Controller **SHOULD** provide a callback endpoint. The Data Controller **SHOULD** verify response signatures. Referenced as "Controller."
 
 #### Data Processor
 
-  The organization that processes data pursuant to the instructions of the Controller on behalf of the Controller. The Data Processor receives data subject requests via RESTful endpoints and is responsible for fulfilling requests. The Data Processor **MUST** provide a signed response to requests. The Data Processor **MUST** honor callbacks.  Data Processors **MUST** honor callbacks included in requests. 
+  The organization that processes data pursuant to the instructions of the Controller on behalf of the Controller. The Data Processor receives data subject requests via RESTful endpoints and is responsible for fulfilling requests. The Data Processor **MUST** provide a signed response to requests. The Data Processor **MUST** honor callbacks.  Data Processors **MUST** honor callbacks included in requests.
 
-  Processors **MUST** provide the following endpoints: 
+  Processors **MUST** provide the following endpoints:
 
   - `/discovery`
   - `/status`
@@ -265,11 +265,11 @@ OpenGDPR service implementations **MUST** provide an endpoint that creates OpenG
 
 #### 7.1.2 Extensions
 
-OpenGDPR requests may contain an `extensions` object, composed of a series of child-objects, keyed by a processor domain. 
+OpenGDPR requests may contain an `extensions` object, composed of a series of child-objects, keyed by a processor domain.
 
 - The domain of each extension **MUST** match the processor's OpenGDPR domain, matching the `X-OpenGDPR-Processor-Domain` header in OpenGDPR responses.
-- Extensions **MUST** not be used for or contain authentication information. 
-- Processors **MUST** only implement an extension for items that do not already fit into the generic spec. 
+- Extensions **MUST** not be used for or contain authentication information.
+- Processors **MUST** only implement an extension for items that do not already fit into the generic spec.
 
 [Currently known extensions can be found here](OpenGDPR_extensions.md).
 
@@ -633,11 +633,6 @@ code 202, and the following parameters:
 
   **REQUIRED** RFC 3339 date string representing the time when the Processor received the cancellation request.
 
-`encoded_request`
-
-  **REQUIRED** Base64 encoding of the entire body of the OpenGDPR request.
-  Controllers **MUST** not log or store this.
-
 `subject_request_id`
 
   **REQUIRED** UUID v4 string from the originating OpenGDPR request.
@@ -673,7 +668,6 @@ KD/4Axmo9DISib5/7A6uczJxQG2Bcrdj++vQqK2succ=
   "controller_id": "example_controller_id",
   "subject_request_id": "a7551968-d5d6-44b2-9831-815ac9017798",
   "received_time": "2018-10-02T15:00:01Z",
-  "encoded_request": "<BASE64 ENCODED REQUEST>",
   "api_version": "0.1"
 }
 ```


### PR DESCRIPTION
Encoded request field not needed in reply to cancellation as the request has no body