### PR TITLE
added Singular to the list of SUPPORTERS

### DIFF
--- a/SUPPORTERS.md
+++ b/SUPPORTERS.md
@@ -1,3 +1,4 @@
 An ongoing list of companies and organizations that have implemented the OpenGDPR Spec:
 - mParticle
 - AppsFlyer
+- Singular


### PR DESCRIPTION
Singular implemented OpenGDPR, docs are available online under: https://developers.singular.net/v2.0/reference#gdpr